### PR TITLE
Reset test database after each test

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -2,6 +2,7 @@ import io
 
 import pandas as pd
 import pytest
+import simple_db
 from fastapi.testclient import TestClient
 from main import app
 from simple_db import init_db
@@ -13,7 +14,18 @@ def setup_database():
     """Setup test database before each test"""
     init_db()
     yield
-    # Cleanup after test
+    # Cleanup after test to ensure fresh state
+    db = simple_db.get_db()
+    cursor = db.connection.cursor()
+    cursor.executescript(
+        """
+        DROP TABLE IF EXISTS projects;
+        DROP TABLE IF EXISTS developers;
+        DROP TABLE IF EXISTS transactions;
+        """
+    )
+    db.close()
+    simple_db._db_instance = None
 
 class TestHealthEndpoints:
     def test_root_health_check(self):


### PR DESCRIPTION
## Summary
- Ensure integration tests close and reset the in-memory SimpleDB after each test
- Drop test tables and clear global DB instance to guarantee a fresh state

## Testing
- `pytest -c /dev/null backend/tests/test_api.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68958b8f7f60832d9e43d115f762a9fe